### PR TITLE
💩 attaches authorization from request.body.params to header

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@arranger/server": "0.3.6",
     "babel-polyfill": "^6.26.0",
+    "body-parser": "^1.18.2",
     "chalk-animation": "^1.5.0",
     "cors": "^2.8.4",
     "ego-token-middleware": "0.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,9 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use((req, res, next) => {
   if (req.body && req.body.httpHeaders) {
     const httpHeaders = JSON.parse(req.body.httpHeaders);
-    if (httpHeaders.authorization) {
-      req.headers.authorization =
-        req.headers.authorization || httpHeaders.authorization;
-    }
+    Object.entries(httpHeaders).forEach(([key, value]) => {
+      req.headers[key] = value;
+    });
   }
   next();
 }, egoToken({ required: true, egoURL }));

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,11 @@ app.use(bodyParser.urlencoded({ extended: true }));
 // This middleware extracts the authorization key from form submissions and
 // attaches it on the request header for the middleware to process.
 app.use((req, res, next) => {
-  if (req.body && req.body.params) {
-    const params = JSON.parse(req.body.params);
-    if (params.authorization) {
+  if (req.body && req.body.httpHeaders) {
+    const httpHeaders = JSON.parse(req.body.httpHeaders);
+    if (httpHeaders.authorization) {
       req.headers.authorization =
-        req.headers.authorization || params.authorization;
+        req.headers.authorization || httpHeaders.authorization;
     }
   }
   next();


### PR DESCRIPTION
This actually will work without having to modify the middleware because the `authorization` key is attached to the header rather than the body. We can revert the change in the middleware to no longer look in the body