### PR TITLE
updates node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon index"
+    "start": "node index",
+    "watch": "nodemon index"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
nodemon should only be used for dev. In EC2, the pm2 process is running the `start` script which is triggering nodemon.