### PR TITLE
🐛 riff fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const app = express();
 const http = Server(app);
 const io = socketIO(http);
 app.use(cors());
-app.get("/s/:shortUrl", shortUrlStatic({ contentAccessor: "value.content" }));
+app.get("/s/:shortUrl", shortUrlStatic());
 
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/src/shortUrlStatic.js
+++ b/src/shortUrlStatic.js
@@ -6,6 +6,8 @@ export default ({ contentAccessor = "content" } = {}) => (req, res) => {
   fetch(urlJoin(process.env.RIFF_API, req.params.shortUrl))
     .then(r => r.json())
     .then(data => {
+      let error = get(data, "error");
+      if (error) console.log(JSON.stringify(data, null, 2));
       let content = get(data, contentAccessor, {});
       let html = `
         <html>
@@ -18,10 +20,13 @@ export default ({ contentAccessor = "content" } = {}) => (req, res) => {
             <meta property="og:image" content="${content["og:image"]}" />
           </head>
           <body>
-            <script>window.location.href = "${content.longUrl}"</script>
+            ${error ||
+              (content.longUrl
+                ? `<script>window.location.href = "${content.longUrl}"</script>`
+                : `URL not found`)}
           </body>
         </html>
-      )`;
+      `;
 
       res.send(html);
     })

--- a/src/shortUrlStatic.js
+++ b/src/shortUrlStatic.js
@@ -7,7 +7,6 @@ export default ({ contentAccessor = "content" } = {}) => (req, res) => {
     .then(r => r.json())
     .then(data => {
       let error = get(data, "error");
-      if (error) console.log(JSON.stringify(data, null, 2));
       let content = get(data, contentAccessor, {});
       let html = `
         <html>


### PR DESCRIPTION
a couple things:
- riff responses now give us content in `content`, not `value.content`
- if `content.longUrl` wasn't present then the previous behaviour was an in-browser infinite reload loop