### PR TITLE
🔒 restrict arranger resolvers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       }
     },
     "@arranger/server": {
+<<<<<<< HEAD
       "version": "0.3.50",
       "resolved": "https://registry.npmjs.org/@arranger/server/-/server-0.3.50.tgz",
       "integrity": "sha512-IzjMJLoWxSdvavr7bDOpsZobqdGr6htfG8cXqY9P+72nvJ6z24KHKr72157jNMlkig+5a7Xcsguc+nSXcheRsg==",
@@ -76,6 +77,81 @@
         "through2": "^2.0.3",
         "url-join": "^4.0.0",
         "uuid": "^3.2.1"
+=======
+      "version": "0.3.51",
+      "resolved": "https://registry.npmjs.org/@arranger/server/-/server-0.3.51.tgz",
+      "integrity": "sha512-hcbT0E0sTn103oaLsci/aI4a7cgo9yEsxkX4rrW+V5vpDJ+BrfOhvg+29yKyvLb4bAeh4iIX/AaR/vrvHD7eqg==",
+      "requires": {
+        "@arranger/mapping-utils": "0.3.51",
+        "@arranger/middleware": "0.3.51",
+        "@arranger/schema": "0.3.51",
+        "apollo-server-express": "1.3.6",
+        "babel-polyfill": "6.26.0",
+        "body-parser": "1.18.2",
+        "chalk": "2.3.2",
+        "chalk-animation": "1.5.1",
+        "cors": "2.8.4",
+        "dotenv": "5.0.1",
+        "elasticsearch": "14.2.2",
+        "express": "4.16.3",
+        "graphql": "0.11.7",
+        "jsonpath": "1.0.0",
+        "node-fetch": "2.1.1",
+        "socket.io": "2.0.4",
+        "socket.io-stream": "0.9.1",
+        "tar-stream": "1.6.1",
+        "through2": "2.0.3",
+        "url-join": "4.0.0",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "@arranger/mapping-utils": {
+          "version": "0.3.51",
+          "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.51.tgz",
+          "integrity": "sha512-QDmJY2ltrM7lJbPneY7zY2OSRnewN1fLMs7rfQthPeU3TzvcQ9lnGKf4gPjD2tjNVZYsCOkWs+RDOhCfqv7ZMg==",
+          "requires": {
+            "@arranger/middleware": "0.3.51",
+            "babel-polyfill": "6.26.0",
+            "elasticsearch": "14.2.2",
+            "graphql-fields": "1.0.2",
+            "lodash": "4.17.5",
+            "node-fetch": "2.1.1",
+            "uuid": "3.2.1"
+          }
+        },
+        "@arranger/middleware": {
+          "version": "0.3.51",
+          "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.51.tgz",
+          "integrity": "sha512-YeSQU1eEMVfEc3mM/rTduRjoSylFGy9NqS3LK2dU2yYuQZfg8+26ucZQFKkdO1m2NBhDKwtv3uvQK5JNFjVVlw==",
+          "requires": {
+            "body-parser": "1.18.2",
+            "cors": "2.8.4",
+            "date-fns": "1.29.0",
+            "express": "4.16.3",
+            "lodash": "4.17.5",
+            "morgan": "1.9.0",
+            "utf8": "3.0.0",
+            "winston": "2.4.2"
+          }
+        },
+        "@arranger/schema": {
+          "version": "0.3.51",
+          "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-0.3.51.tgz",
+          "integrity": "sha512-O3oBUQJFGV72vnN5T5tf6FZ1d/Wp/ZEjuFBXAtp0T82plgAW+xjew7TViJBrq/IhV65143+dez4orZp/G1lBNQ==",
+          "requires": {
+            "@arranger/mapping-utils": "0.3.51",
+            "@arranger/middleware": "0.3.51",
+            "babel-polyfill": "6.26.0",
+            "elasticsearch": "14.2.2",
+            "graphql-middleware": "1.2.1",
+            "graphql-scalars": "0.1.5",
+            "graphql-tools": "2.24.0",
+            "graphql-type-json": "0.1.4",
+            "lodash": "4.17.5",
+            "uuid": "3.2.1"
+          }
+        }
+>>>>>>> 3b7994d... :lock: restrict admin-only graphql resolvers via middleware
       }
     },
     "@babel/code-frame": {
@@ -4256,7 +4332,19 @@
       "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-1.2.1.tgz",
       "integrity": "sha512-c0P4SRXLzsPpkWrcRRYUhMz+PgJPG6r74a+wXfy6Le0aUlmK3GL3CQBYneOIAhS+MRLRiAbW0ZKPjSYv36dx1Q==",
       "requires": {
+<<<<<<< HEAD
         "graphql-tools": "^2.23.1"
+=======
+        "graphql-tools": "2.24.0"
+      }
+    },
+    "graphql-parse-resolve-info": {
+      "version": "4.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.0.0-beta.7.tgz",
+      "integrity": "sha512-fvlE8fkI01V8l8zc7iiNYxPJyfhltVHyuSZnb4o3wMryzTH7ri8LjC4s4qb3C7LXHyyx9FzM7b0FbLKE/HACJA==",
+      "requires": {
+        "debug": "2.6.9"
+>>>>>>> 3b7994d... :lock: restrict admin-only graphql resolvers via middleware
       }
     },
     "graphql-scalars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,33 +51,6 @@
       }
     },
     "@arranger/server": {
-<<<<<<< HEAD
-      "version": "0.3.50",
-      "resolved": "https://registry.npmjs.org/@arranger/server/-/server-0.3.50.tgz",
-      "integrity": "sha512-IzjMJLoWxSdvavr7bDOpsZobqdGr6htfG8cXqY9P+72nvJ6z24KHKr72157jNMlkig+5a7Xcsguc+nSXcheRsg==",
-      "requires": {
-        "@arranger/mapping-utils": "^0.3.50",
-        "@arranger/middleware": "^0.3.50",
-        "@arranger/schema": "^0.3.50",
-        "apollo-server-express": "^1.3.1",
-        "babel-polyfill": "^6.26.0",
-        "body-parser": "^1.18.2",
-        "chalk": "^2.3.1",
-        "chalk-animation": "^1.3.0",
-        "cors": "^2.8.4",
-        "dotenv": "^5.0.0",
-        "elasticsearch": "^14.0.0",
-        "express": "^4.16.2",
-        "graphql": "^0.11.0",
-        "jsonpath": "^1.0.0",
-        "node-fetch": "^2.0.0",
-        "socket.io": "^2.0.4",
-        "socket.io-stream": "^0.9.1",
-        "tar-stream": "^1.5.5",
-        "through2": "^2.0.3",
-        "url-join": "^4.0.0",
-        "uuid": "^3.2.1"
-=======
       "version": "0.3.51",
       "resolved": "https://registry.npmjs.org/@arranger/server/-/server-0.3.51.tgz",
       "integrity": "sha512-hcbT0E0sTn103oaLsci/aI4a7cgo9yEsxkX4rrW+V5vpDJ+BrfOhvg+29yKyvLb4bAeh4iIX/AaR/vrvHD7eqg==",
@@ -151,7 +124,6 @@
             "uuid": "3.2.1"
           }
         }
->>>>>>> 3b7994d... :lock: restrict admin-only graphql resolvers via middleware
       }
     },
     "@babel/code-frame": {
@@ -4332,9 +4304,6 @@
       "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-1.2.1.tgz",
       "integrity": "sha512-c0P4SRXLzsPpkWrcRRYUhMz+PgJPG6r74a+wXfy6Le0aUlmK3GL3CQBYneOIAhS+MRLRiAbW0ZKPjSYv36dx1Q==",
       "requires": {
-<<<<<<< HEAD
-        "graphql-tools": "^2.23.1"
-=======
         "graphql-tools": "2.24.0"
       }
     },
@@ -4344,7 +4313,6 @@
       "integrity": "sha512-fvlE8fkI01V8l8zc7iiNYxPJyfhltVHyuSZnb4o3wMryzTH7ri8LjC4s4qb3C7LXHyyx9FzM7b0FbLKE/HACJA==",
       "requires": {
         "debug": "2.6.9"
->>>>>>> 3b7994d... :lock: restrict admin-only graphql resolvers via middleware
       }
     },
     "graphql-scalars": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
   },
   "homepage": "https://github.com/kids-first/kf-arranger#readme",
   "dependencies": {
-    "@arranger/server": "^0.3.50",
+    "@arranger/server": "^0.3.51",
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.2",
     "chalk-animation": "^1.5.0",
     "cors": "^2.8.4",
     "ego-token-middleware": "0.0.8",
     "express": "^4.16.2",
+    "graphql-parse-resolve-info": "^4.0.0-beta.7",
     "node-fetch": "^2.1.1",
     "socket.io": "^2.0.4",
     "url-join": "^4.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import bodyParser from "body-parser";
 
 import { port, egoURL, projectId, esHost } from "./env";
 import shortUrlStatic from "./shortUrlStatic";
-import { injectBodyHttpHeaders } from "./middleware";
+import { onlyAdminMutations, injectBodyHttpHeaders } from "./middleware";
 
 const app = express();
 const http = Server(app);
@@ -26,6 +26,7 @@ app.use(injectBodyHttpHeaders());
 app.use(
   egoTokenMiddleware({
     egoURL,
+    required: true,
     accessRules: [
       {
         type: "allow",
@@ -51,7 +52,15 @@ app.use(
   })
 );
 
-Arranger({ io, projectId, esHost }).then(router => {
+Arranger({
+  io,
+  projectId,
+  esHost,
+  graphqlOptions: {
+    context: ({ jwt }) => ({ jwt }),
+    middleware: [onlyAdminMutations]
+  }
+}).then(router => {
   app.use(router);
   http.listen(port, async () => {
     rainbow(`⚡️ Listening on port ${port} ⚡️`);

--- a/src/middleware/graphqlMiddleware.js
+++ b/src/middleware/graphqlMiddleware.js
@@ -1,0 +1,15 @@
+import { get } from "lodash";
+import { parseResolveInfo } from "graphql-parse-resolve-info";
+
+const toLower = x => (x || "").toLowerCase();
+
+export const onlyAdminMutations = {
+  Mutation: (resolve, parent, args, context, info) => {
+    const { name } = parseResolveInfo(info);
+    const roles = get(context, "jwt.context.user.roles", []);
+    if (name !== "saveSet" && !roles.map(toLower).includes("admin")) {
+      throw new Error("Unauthorized - Administrator role is required");
+    }
+    return resolve(parent, args, context, info);
+  }
+};

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,1 +1,2 @@
+export { onlyAdminMutations } from "./graphqlMiddleware";
 export { default as injectBodyHttpHeaders } from "./injectBodyHttpHeaders";


### PR DESCRIPTION
this repacks `jwt` from request context into graphql context, and adds middleware to guard all mutations (except for `saveSet`) from non-admins.

@alex-wilmer - instantiation of the arranger middleware / context opts