### PR TITLE
Dockerized and Status Endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git
+target
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM keymetrics/pm2:latest-alpine
+
+WORKDIR /usr/src/app
+
+RUN npm install pm2 -g
+RUN npm install
+
+COPY . .
+
+CMD ["pm2-runtime", "index.js"]
+

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ import cors from "cors";
 import bodyParser from "body-parser";
 
 import { port, egoURL, projectId, esHost } from "./env";
+import {version} from '../package.json';
+
 import shortUrlStatic from "./shortUrlStatic";
 import { onlyAdminMutations, injectBodyHttpHeaders } from "./middleware";
 
@@ -19,6 +21,8 @@ const io = socketIO(http);
 
 app.use(cors());
 app.get("/s/:shortUrl", shortUrlStatic());
+
+app.get('/status', (req, res) => res.send({ version, ego: egoURL, project: projectId, elasticsearch: esHost }));
 
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -51,6 +55,8 @@ app.use(
     ]
   })
 );
+
+
 
 Arranger({
   io,


### PR DESCRIPTION
Status endpoint requires no authorization. This is a useful thing to check for the current arranger status. At least one non-secured endpoint that returns status 200 is needed for the AWS health check, this will satisfy that requirement.