### PR TITLE
:construction_worker: New Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 @Library(value="kids-first/aws-infra-jenkins-shared-libraries", changelog=false) _
-ecs_service_type_1 {
+ecs_service_type_1_standard {
     projectName = "kf-arranger"
     agentLabel = "terraform-testing"
 }


### PR DESCRIPTION
Changing to use new Jenkinsfile with capability to destroy dev environment after non-master branch deploy.